### PR TITLE
[Feat] Piano Keyboard Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import PianoKeyboard from './components/PianoKeyboard'
+import { useAudioEngine } from './hooks/useAudioEngine'
 
 export default function App(): React.JSX.Element {
+  const { playNote, stopNote } = useAudioEngine()
   return (
     <div className="app">
       <h1>Piano</h1>
@@ -10,8 +12,8 @@ export default function App(): React.JSX.Element {
         octaves={2}
         showNoteLabels={true}
         showShortcutLabels={true}
-        onNoteOn={(note, velocity) => console.log('noteOn', note, velocity)}
-        onNoteOff={(note) => console.log('noteOff', note)}
+        onNoteOn={playNote}
+        onNoteOff={stopNote}
       />
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,21 @@
 import React from 'react'
+import { useAudioEngine } from './hooks/useAudioEngine'
+
+// PianoKeyboard component will be added in Issue #2
+// import PianoKeyboard from './components/PianoKeyboard'
 
 export default function App(): React.JSX.Element {
+  const { playNote, stopNote, isReady } = useAudioEngine()
+
   return (
     <div className="app">
       <h1>Piano</h1>
-      <p>Minimal scaffold for the Piano web app.</p>
-      <div className="piano">[Piano component will go here — see issue #2]</div>
+      <p>Audio engine ready: {isReady ? '✅' : '⏳ (click a key to activate)'}</p>
+      <div className="piano">
+        {/* PianoKeyboard will go here — see issue #2 */}
+        {/* Once available: <PianoKeyboard onNoteOn={playNote} onNoteOff={stopNote} /> */}
+        <p>[Piano component will go here — see issue #2]</p>
+      </div>
     </div>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,18 @@
 import React from 'react'
-import { useAudioEngine } from './hooks/useAudioEngine'
-
-// PianoKeyboard component will be added in Issue #2
-// import PianoKeyboard from './components/PianoKeyboard'
+import PianoKeyboard from './components/PianoKeyboard'
 
 export default function App(): React.JSX.Element {
-  const { playNote, stopNote, isReady } = useAudioEngine()
-
   return (
     <div className="app">
       <h1>Piano</h1>
-      <p>Audio engine ready: {isReady ? '✅' : '⏳ (click a key to activate)'}</p>
-      <div className="piano">
-        {/* PianoKeyboard will go here — see issue #2 */}
-        {/* Once available: <PianoKeyboard onNoteOn={playNote} onNoteOff={stopNote} /> */}
-        <p>[Piano component will go here — see issue #2]</p>
-      </div>
+      <PianoKeyboard
+        baseOctave={3}
+        octaves={2}
+        showNoteLabels={true}
+        showShortcutLabels={true}
+        onNoteOn={(note, velocity) => console.log('noteOn', note, velocity)}
+        onNoteOff={(note) => console.log('noteOff', note)}
+      />
     </div>
   )
 }

--- a/src/audio/audioEngine.ts
+++ b/src/audio/audioEngine.ts
@@ -1,0 +1,129 @@
+import { InstrumentConfig, pianoInstrument } from './instruments'
+
+interface ActiveNote {
+  oscillator: OscillatorNode
+  oscillator2?: OscillatorNode
+  gainNode: GainNode
+}
+
+/**
+ * Converts a note string like 'C4', 'C#4', 'Bb3' to frequency in Hz.
+ * Uses equal temperament: A4 = 440 Hz
+ */
+export function noteToFrequency(note: string): number {
+  const noteMap: Record<string, number> = {
+    C: 0, 'C#': 1, Db: 1, D: 2, 'D#': 3, Eb: 3,
+    E: 4, F: 5, 'F#': 6, Gb: 6, G: 7, 'G#': 8,
+    Ab: 8, A: 9, 'A#': 10, Bb: 10, B: 11,
+  }
+
+  const match = note.match(/^([A-G][#b]?)(\d+)$/)
+  if (!match) throw new Error(`Invalid note: ${note}`)
+
+  const [, noteName, octaveStr] = match
+  const semitone = noteMap[noteName]
+  if (semitone === undefined) throw new Error(`Unknown note name: ${noteName}`)
+
+  const octave = parseInt(octaveStr, 10)
+  // MIDI note number: A4 = 69
+  const midiNote = (octave + 1) * 12 + semitone
+  return 440 * Math.pow(2, (midiNote - 69) / 12)
+}
+
+export class AudioEngine {
+  private context: AudioContext | null = null
+  private activeNotes: Map<string, ActiveNote> = new Map()
+  private instrument: InstrumentConfig
+
+  constructor(instrument: InstrumentConfig = pianoInstrument) {
+    this.instrument = instrument
+  }
+
+  /** Initialize or resume AudioContext (must be called from user gesture) */
+  async initialize(): Promise<void> {
+    if (!this.context) {
+      this.context = new AudioContext()
+    }
+    if (this.context.state === 'suspended') {
+      await this.context.resume()
+    }
+  }
+
+  get isReady(): boolean {
+    return this.context?.state === 'running'
+  }
+
+  playNote(note: string, velocity: number = 1): void {
+    if (!this.context || this.context.state !== 'running') return
+
+    // Stop existing note with same key if already playing
+    if (this.activeNotes.has(note)) {
+      this.stopNote(note)
+    }
+
+    const ctx = this.context
+    const { oscillatorType, attack, decay, sustain, gainMultiplier, detune } = this.instrument
+    const freq = noteToFrequency(note)
+    const now = ctx.currentTime
+
+    const gainNode = ctx.createGain()
+    gainNode.gain.setValueAtTime(0, now)
+    gainNode.gain.linearRampToValueAtTime(gainMultiplier * velocity, now + attack)
+    gainNode.gain.linearRampToValueAtTime(gainMultiplier * velocity * sustain, now + attack + decay)
+    gainNode.connect(ctx.destination)
+
+    const osc1 = ctx.createOscillator()
+    osc1.type = oscillatorType
+    osc1.frequency.setValueAtTime(freq, now)
+    osc1.connect(gainNode)
+    osc1.start(now)
+
+    let osc2: OscillatorNode | undefined
+    if (detune !== undefined) {
+      osc2 = ctx.createOscillator()
+      osc2.type = 'sine'
+      osc2.frequency.setValueAtTime(freq, now)
+      osc2.detune.setValueAtTime(detune, now)
+      osc2.connect(gainNode)
+      osc2.start(now)
+    }
+
+    this.activeNotes.set(note, { oscillator: osc1, oscillator2: osc2, gainNode })
+  }
+
+  stopNote(note: string): void {
+    const active = this.activeNotes.get(note)
+    if (!active || !this.context) return
+
+    const ctx = this.context
+    const { release } = this.instrument
+    const now = ctx.currentTime
+
+    active.gainNode.gain.cancelScheduledValues(now)
+    active.gainNode.gain.setValueAtTime(active.gainNode.gain.value, now)
+    active.gainNode.gain.linearRampToValueAtTime(0, now + release)
+
+    const stopTime = now + release + 0.01
+    active.oscillator.stop(stopTime)
+    active.oscillator2?.stop(stopTime)
+
+    this.activeNotes.delete(note)
+
+    // Clean up gain node after release
+    setTimeout(() => {
+      active.gainNode.disconnect()
+    }, (release + 0.1) * 1000)
+  }
+
+  stopAll(): void {
+    for (const note of this.activeNotes.keys()) {
+      this.stopNote(note)
+    }
+  }
+
+  dispose(): void {
+    this.stopAll()
+    this.context?.close()
+    this.context = null
+  }
+}

--- a/src/audio/instruments.ts
+++ b/src/audio/instruments.ts
@@ -1,0 +1,23 @@
+export interface InstrumentConfig {
+  oscillatorType: OscillatorType
+  attack: number
+  decay: number
+  sustain: number
+  release: number
+  gainMultiplier: number
+  /** Optional second oscillator for richer tone */
+  detune?: number
+}
+
+/** Piano-like tone using triangle + slight detuned sine */
+export const pianoInstrument: InstrumentConfig = {
+  oscillatorType: 'triangle',
+  attack: 0.01,
+  decay: 0.1,
+  sustain: 0.7,
+  release: 0.3,
+  gainMultiplier: 0.5,
+  detune: 3,
+}
+
+export default pianoInstrument

--- a/src/components/Piano.css
+++ b/src/components/Piano.css
@@ -1,0 +1,126 @@
+/* Piano CSS */
+.piano-keyboard-wrapper {
+  --piano-white-key-width: clamp(20px, 2.3vw, 26px);
+  --piano-white-key-height: clamp(100px, 12vw, 140px);
+  --piano-black-key-width: calc(var(--piano-white-key-width) * 0.6);
+  --piano-black-key-height: calc(var(--piano-white-key-height) * 0.65);
+  --piano-color-accent: #0b84ff;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  user-select: none;
+}
+
+.piano-octave-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.piano-octave-controls button {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #f5f5f5;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.piano-octave-controls button:hover {
+  background: #e0e0e0;
+}
+
+.piano-octave-label {
+  font-size: 0.9rem;
+  color: #555;
+  min-width: 80px;
+  text-align: center;
+}
+
+.piano-keys {
+  position: relative;
+  display: flex;
+  height: var(--piano-white-key-height);
+}
+
+.piano-key {
+  position: relative;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  padding-bottom: 4px;
+  transition: background 0.05s;
+}
+
+.piano-key--white {
+  width: var(--piano-white-key-width);
+  height: var(--piano-white-key-height);
+  background: #fff;
+  border: 1px solid #999;
+  border-radius: 0 0 4px 4px;
+  z-index: 1;
+}
+
+.piano-key--white:hover {
+  background: #f0f8ff;
+}
+
+.piano-key--white.piano-key--active {
+  background: var(--piano-color-accent);
+}
+
+.piano-key--black {
+  width: var(--piano-black-key-width);
+  height: var(--piano-black-key-height);
+  background: #222;
+  border-radius: 0 0 3px 3px;
+  z-index: 2;
+  margin-left: calc(var(--piano-black-key-width) / -2);
+  margin-right: calc(var(--piano-black-key-width) / -2);
+  border: 1px solid #000;
+}
+
+.piano-key--black:hover {
+  background: #444;
+}
+
+.piano-key--black.piano-key--active {
+  background: var(--piano-color-accent);
+}
+
+.piano-key__labels {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  pointer-events: none;
+}
+
+.piano-key__shortcut {
+  font-size: 8px;
+  color: #999;
+  font-family: monospace;
+}
+
+.piano-key--black .piano-key__shortcut {
+  color: #aaa;
+}
+
+.piano-key__note {
+  font-size: 9px;
+  color: #666;
+  font-family: system-ui, sans-serif;
+}
+
+@media (max-width: 600px) {
+  .piano-keyboard-wrapper {
+    --piano-white-key-width: clamp(16px, 4vw, 22px);
+    --piano-white-key-height: clamp(80px, 18vw, 110px);
+  }
+}

--- a/src/components/PianoKey.tsx
+++ b/src/components/PianoKey.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import type { PianoKeyProps } from '../types/piano'
+import './Piano.css'
+
+export default function PianoKey({
+  keyData,
+  isActive,
+  showNoteLabel,
+  showShortcutLabel,
+  onNoteOn,
+  onNoteOff,
+}: PianoKeyProps): React.JSX.Element {
+  const { note, isBlack, shortcut } = keyData
+  const noteName = note.replace(/\d/, '')
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault()
+    onNoteOn(note, 100)
+  }
+  const handleMouseUp = () => onNoteOff(note)
+  const handleMouseLeave = () => {
+    if (isActive) onNoteOff(note)
+  }
+
+  return (
+    <button
+      className={`piano-key ${isBlack ? 'piano-key--black' : 'piano-key--white'} ${isActive ? 'piano-key--active' : ''}`}
+      aria-label={note}
+      aria-pressed={isActive}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
+      onTouchStart={(e) => { e.preventDefault(); onNoteOn(note, 100) }}
+      onTouchEnd={() => onNoteOff(note)}
+    >
+      <span className="piano-key__labels">
+        {showShortcutLabel && shortcut && (
+          <span className="piano-key__shortcut">{shortcut}</span>
+        )}
+        {showNoteLabel && !isBlack && (
+          <span className="piano-key__note">{noteName}</span>
+        )}
+      </span>
+    </button>
+  )
+}

--- a/src/components/PianoKeyboard.tsx
+++ b/src/components/PianoKeyboard.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useCallback } from 'react'
+import PianoKey from './PianoKey'
+import { useKeyboard, NOTE_TO_KEY } from '../hooks/useKeyboard'
+import type { PianoKeyboardProps, PianoKeyData } from '../types/piano'
+import './Piano.css'
+
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+
+function buildKeys(baseOctave: number, octaves: number): PianoKeyData[] {
+  const keys: PianoKeyData[] = []
+  for (let o = 0; o < octaves; o++) {
+    const octave = baseOctave + o
+    for (const name of NOTE_NAMES) {
+      const note = `${name}${octave}`
+      const isBlack = name.includes('#')
+      keys.push({ note, isBlack, octave, shortcut: NOTE_TO_KEY[note] })
+    }
+  }
+  return keys
+}
+
+export default function PianoKeyboard({
+  baseOctave = 3,
+  octaves = 2,
+  showNoteLabels = true,
+  showShortcutLabels = true,
+  onNoteOn,
+  onNoteOff,
+}: PianoKeyboardProps): React.JSX.Element {
+  const [currentBase, setCurrentBase] = useState(baseOctave)
+  const [activeNotes, setActiveNotes] = useState<Set<string>>(new Set())
+
+  const handleNoteOn = useCallback((note: string, velocity: number) => {
+    setActiveNotes(prev => new Set([...prev, note]))
+    onNoteOn?.(note, velocity)
+  }, [onNoteOn])
+
+  const handleNoteOff = useCallback((note: string) => {
+    setActiveNotes(prev => {
+      const next = new Set(prev)
+      next.delete(note)
+      return next
+    })
+    onNoteOff?.(note)
+  }, [onNoteOff])
+
+  useKeyboard(handleNoteOn, handleNoteOff)
+
+  const keys = buildKeys(currentBase, octaves)
+  const lastOctave = currentBase + octaves - 1
+  const rangeLabel = `C${currentBase} – B${lastOctave}`
+
+  // Separate white and black keys for rendering
+  const whiteKeys = keys.filter(k => !k.isBlack)
+  const blackKeys = keys.filter(k => k.isBlack)
+
+  // Calculate black key positions (offset from left in units of white key widths)
+  // We need to track white key index for each black key
+  const blackKeyPositions: { key: PianoKeyData; whiteIndex: number }[] = []
+  let whiteIdx = 0
+  for (const k of keys) {
+    if (!k.isBlack) {
+      whiteIdx++
+    } else {
+      // black key sits between previous white key and next
+      blackKeyPositions.push({ key: k, whiteIndex: whiteIdx - 0.5 })
+    }
+  }
+
+  return (
+    <div className="piano-keyboard-wrapper">
+      <div className="piano-octave-controls">
+        <button onClick={() => setCurrentBase(b => Math.max(0, b - 1))}>◀</button>
+        <span className="piano-octave-label">{rangeLabel}</span>
+        <button onClick={() => setCurrentBase(b => Math.min(8, b + 1))}>▶</button>
+      </div>
+      <div className="piano-keys" style={{ position: 'relative' }}>
+        {/* White keys */}
+        {whiteKeys.map(k => (
+          <PianoKey
+            key={k.note}
+            keyData={k}
+            isActive={activeNotes.has(k.note)}
+            showNoteLabel={showNoteLabels}
+            showShortcutLabel={showShortcutLabels}
+            onNoteOn={handleNoteOn}
+            onNoteOff={handleNoteOff}
+          />
+        ))}
+        {/* Black keys overlay */}
+        <div style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none', display: 'contents' }}>
+          {blackKeyPositions.map(({ key: k, whiteIndex }) => (
+            <div
+              key={k.note}
+              style={{
+                position: 'absolute',
+                left: `calc(${whiteIndex} * var(--piano-white-key-width))`,
+                top: 0,
+                transform: 'translateX(-50%)',
+                pointerEvents: 'auto',
+                zIndex: 2,
+              }}
+            >
+              <PianoKey
+                keyData={k}
+                isActive={activeNotes.has(k.note)}
+                showNoteLabel={false}
+                showShortcutLabel={showShortcutLabels}
+                onNoteOn={handleNoteOn}
+                onNoteOff={handleNoteOff}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AudioEngine } from '../audio/audioEngine'
+import { pianoInstrument } from '../audio/instruments'
+
+export interface AudioEngineHook {
+  playNote: (note: string, velocity?: number) => void
+  stopNote: (note: string) => void
+  isReady: boolean
+}
+
+export function useAudioEngine(): AudioEngineHook {
+  const engineRef = useRef<AudioEngine | null>(null)
+  const [isReady, setIsReady] = useState(false)
+
+  // Lazily create engine
+  if (!engineRef.current) {
+    engineRef.current = new AudioEngine(pianoInstrument)
+  }
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      engineRef.current?.dispose()
+      engineRef.current = null
+    }
+  }, [])
+
+  const ensureReady = useCallback(async () => {
+    const engine = engineRef.current
+    if (!engine) return
+    if (!engine.isReady) {
+      await engine.initialize()
+      setIsReady(engine.isReady)
+    }
+  }, [])
+
+  const playNote = useCallback(
+    async (note: string, velocity?: number) => {
+      await ensureReady()
+      engineRef.current?.playNote(note, velocity)
+      if (!isReady) setIsReady(engineRef.current?.isReady ?? false)
+    },
+    [ensureReady, isReady]
+  )
+
+  const stopNote = useCallback((note: string) => {
+    engineRef.current?.stopNote(note)
+  }, [])
+
+  return { playNote, stopNote, isReady }
+}
+
+export default useAudioEngine

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,0 +1,38 @@
+import { useEffect, useCallback } from 'react'
+
+// Fixed mapping for 2 octaves starting C3
+const KEY_TO_NOTE: Record<string, string> = {
+  z: 'C3', s: 'C#3', x: 'D3', d: 'D#3', c: 'E3',
+  v: 'F3', g: 'F#3', b: 'G3', h: 'G#3', n: 'A3', j: 'A#3', m: 'B3',
+  q: 'C4', '2': 'C#4', w: 'D4', '3': 'D#4', e: 'E4',
+  r: 'F4', '5': 'F#4', t: 'G4', '6': 'G#4', y: 'A4', '7': 'A#4', u: 'B4',
+}
+
+export const NOTE_TO_KEY: Record<string, string> = Object.fromEntries(
+  Object.entries(KEY_TO_NOTE).map(([k, v]) => [v, k])
+)
+
+export function useKeyboard(
+  onNoteOn: (note: string, velocity: number) => void,
+  onNoteOff: (note: string) => void
+) {
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.repeat) return
+    const note = KEY_TO_NOTE[e.key.toLowerCase()]
+    if (note) onNoteOn(note, 100)
+  }, [onNoteOn])
+
+  const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    const note = KEY_TO_NOTE[e.key.toLowerCase()]
+    if (note) onNoteOff(note)
+  }, [onNoteOff])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+    }
+  }, [handleKeyDown, handleKeyUp])
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,9 +1,9 @@
+@import './tokens.css';
+
 .app {
   font-family: system-ui, Arial, sans-serif;
   padding: 2rem;
 }
-
-@import './tokens.css';
 
 .piano {
   margin-top: 1rem;

--- a/src/types/piano.ts
+++ b/src/types/piano.ts
@@ -1,0 +1,24 @@
+export interface PianoKeyData {
+  note: string        // e.g. "C3", "C#3"
+  isBlack: boolean
+  octave: number
+  shortcut?: string
+}
+
+export interface PianoKeyProps {
+  keyData: PianoKeyData
+  isActive: boolean
+  showNoteLabel?: boolean
+  showShortcutLabel?: boolean
+  onNoteOn: (note: string, velocity: number) => void
+  onNoteOff: (note: string) => void
+}
+
+export interface PianoKeyboardProps {
+  baseOctave?: number
+  octaves?: number
+  showNoteLabels?: boolean
+  showShortcutLabels?: boolean
+  onNoteOn?: (note: string, velocity: number) => void
+  onNoteOff?: (note: string) => void
+}


### PR DESCRIPTION
Implements Issue #2: Piano Keyboard Component.

## Changes
- `src/types/piano.ts` — TypeScript types for PianoKeyData, PianoKeyProps, PianoKeyboardProps
- `src/hooks/useKeyboard.ts` — Computer keyboard → note mapping (2 octaves C3-B4)
- `src/components/PianoKey.tsx` — Individual white/black key component with aria attributes
- `src/components/PianoKeyboard.tsx` — Full keyboard with octave Prev/Next controls
- `src/components/Piano.css` — CSS variables and layout styles per spec
- `src/App.tsx` — Updated to render `<PianoKeyboard />`

## Features
- 2-octave default view with white and black keys
- Octave selector with range display (e.g. C3 – B4)
- Computer keyboard shortcuts (z/x/c... for lower octave, q/w/e... for upper)
- Active state with accent color #0b84ff
- Note labels and keyboard shortcut labels
- Responsive CSS variables
- Mouse and touch event support
- aria-pressed and aria-label accessibility attributes

Closes #2