### PR TITLE
[QA] Unit Tests: Audio Hook and Keyboard Logic

### DIFF
--- a/src/__tests__/PianoKey.test.tsx
+++ b/src/__tests__/PianoKey.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PianoKey from '../components/PianoKey'
+import type { PianoKeyData } from '../types/piano'
+
+const whiteKeyData: PianoKeyData = {
+  note: 'C4',
+  isBlack: false,
+  octave: 4,
+  shortcut: 'q',
+}
+
+const blackKeyData: PianoKeyData = {
+  note: 'C#4',
+  isBlack: true,
+  octave: 4,
+  shortcut: '2',
+}
+
+const defaultProps = {
+  isActive: false,
+  showNoteLabel: false,
+  showShortcutLabel: false,
+  onNoteOn: vi.fn(),
+  onNoteOff: vi.fn(),
+}
+
+describe('PianoKey', () => {
+  it('white key has class containing "white"', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} />)
+    const btn = screen.getByRole('button', { name: 'C4' })
+    expect(btn.className).toContain('white')
+  })
+
+  it('black key has class containing "black"', () => {
+    render(<PianoKey {...defaultProps} keyData={blackKeyData} />)
+    const btn = screen.getByRole('button', { name: 'C#4' })
+    expect(btn.className).toContain('black')
+  })
+
+  it('aria-pressed is false when not active', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} isActive={false} />)
+    const btn = screen.getByRole('button', { name: 'C4' })
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('aria-pressed is true when active', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} isActive={true} />)
+    const btn = screen.getByRole('button', { name: 'C4' })
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('aria-label contains note name', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} />)
+    expect(screen.getByRole('button', { name: 'C4' })).toBeInTheDocument()
+  })
+
+  it('shows note label when showNoteLabel=true (white key)', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} showNoteLabel={true} />)
+    expect(screen.getByText('C')).toBeInTheDocument()
+  })
+
+  it('does not show note label when showNoteLabel=false', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} showNoteLabel={false} />)
+    // No span with note name text
+    expect(screen.queryByText('C')).not.toBeInTheDocument()
+  })
+
+  it('shows shortcut label when showShortcutLabel=true', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} showShortcutLabel={true} />)
+    expect(screen.getByText('q')).toBeInTheDocument()
+  })
+
+  it('does not show shortcut label when showShortcutLabel=false', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} showShortcutLabel={false} />)
+    expect(screen.queryByText('q')).not.toBeInTheDocument()
+  })
+
+  it('calls onNoteOn on mouseDown', () => {
+    const onNoteOn = vi.fn()
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} onNoteOn={onNoteOn} />)
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'C4' }))
+    expect(onNoteOn).toHaveBeenCalledWith('C4', 100)
+  })
+
+  it('calls onNoteOff on mouseUp', () => {
+    const onNoteOff = vi.fn()
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} onNoteOff={onNoteOff} />)
+    fireEvent.mouseUp(screen.getByRole('button', { name: 'C4' }))
+    expect(onNoteOff).toHaveBeenCalledWith('C4')
+  })
+
+  it('calls onNoteOff on mouseLeave when active', () => {
+    const onNoteOff = vi.fn()
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} isActive={true} onNoteOff={onNoteOff} />)
+    fireEvent.mouseLeave(screen.getByRole('button', { name: 'C4' }))
+    expect(onNoteOff).toHaveBeenCalledWith('C4')
+  })
+
+  it('does NOT call onNoteOff on mouseLeave when inactive', () => {
+    const onNoteOff = vi.fn()
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} isActive={false} onNoteOff={onNoteOff} />)
+    fireEvent.mouseLeave(screen.getByRole('button', { name: 'C4' }))
+    expect(onNoteOff).not.toHaveBeenCalled()
+  })
+
+  it('active key has active class', () => {
+    render(<PianoKey {...defaultProps} keyData={whiteKeyData} isActive={true} />)
+    const btn = screen.getByRole('button', { name: 'C4' })
+    expect(btn.className).toContain('active')
+  })
+
+  it('black key does not show note label even with showNoteLabel=true', () => {
+    render(<PianoKey {...defaultProps} keyData={blackKeyData} showNoteLabel={true} />)
+    // black keys don't show note labels per the component logic
+    expect(screen.queryByText('C#')).not.toBeInTheDocument()
+  })
+})

--- a/src/__tests__/PianoKeyboard.test.tsx
+++ b/src/__tests__/PianoKeyboard.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PianoKeyboard from '../components/PianoKeyboard'
+
+describe('PianoKeyboard', () => {
+  it('renders 14 white keys for 2-octave view', () => {
+    render(<PianoKeyboard baseOctave={3} octaves={2} />)
+    // White keys: C D E F G A B = 7 per octave × 2 = 14
+    const allButtons = screen.getAllByRole('button')
+    // Filter out octave control buttons (◀ and ▶) — there are 2 of them
+    const pianoKeys = allButtons.filter(btn =>
+      btn.classList.contains('piano-key--white') || btn.classList.contains('piano-key--black')
+    )
+    const whiteKeys = pianoKeys.filter(btn => btn.classList.contains('piano-key--white'))
+    expect(whiteKeys).toHaveLength(14)
+  })
+
+  it('renders 10 black keys for 2-octave view', () => {
+    render(<PianoKeyboard baseOctave={3} octaves={2} />)
+    const allButtons = screen.getAllByRole('button')
+    const blackKeys = allButtons.filter(btn => btn.classList.contains('piano-key--black'))
+    // Black keys: C# D# F# G# A# = 5 per octave × 2 = 10
+    expect(blackKeys).toHaveLength(10)
+  })
+
+  it('renders prev (◀) and next (▶) octave buttons', () => {
+    render(<PianoKeyboard baseOctave={3} octaves={2} />)
+    expect(screen.getByText('◀')).toBeInTheDocument()
+    expect(screen.getByText('▶')).toBeInTheDocument()
+  })
+
+  it('displays initial range label C3 – B4', () => {
+    render(<PianoKeyboard baseOctave={3} octaves={2} />)
+    expect(screen.getByText('C3 – B4')).toBeInTheDocument()
+  })
+
+  it('Next octave button updates range label', () => {
+    render(<PianoKeyboard baseOctave={3} octaves={2} />)
+    fireEvent.click(screen.getByText('▶'))
+    expect(screen.getByText('C4 – B5')).toBeInTheDocument()
+  })
+
+  it('Prev octave button updates range label', () => {
+    render(<PianoKeyboard baseOctave={3} octaves={2} />)
+    fireEvent.click(screen.getByText('◀'))
+    expect(screen.getByText('C2 – B3')).toBeInTheDocument()
+  })
+
+  it('clicking a white key calls onNoteOn callback', () => {
+    const onNoteOn = vi.fn()
+    render(<PianoKeyboard baseOctave={3} octaves={2} onNoteOn={onNoteOn} />)
+    const whiteKey = screen.getByRole('button', { name: 'C3' })
+    fireEvent.mouseDown(whiteKey)
+    expect(onNoteOn).toHaveBeenCalledWith('C3', 100)
+  })
+
+  it('mouseup on a white key calls onNoteOff callback', () => {
+    const onNoteOff = vi.fn()
+    render(<PianoKeyboard baseOctave={3} octaves={2} onNoteOff={onNoteOff} />)
+    const whiteKey = screen.getByRole('button', { name: 'C3' })
+    fireEvent.mouseDown(whiteKey)
+    fireEvent.mouseUp(whiteKey)
+    expect(onNoteOff).toHaveBeenCalledWith('C3')
+  })
+
+  it('clicking a black key calls onNoteOn callback', () => {
+    const onNoteOn = vi.fn()
+    render(<PianoKeyboard baseOctave={3} octaves={2} onNoteOn={onNoteOn} />)
+    const blackKey = screen.getByRole('button', { name: 'C#3' })
+    fireEvent.mouseDown(blackKey)
+    expect(onNoteOn).toHaveBeenCalledWith('C#3', 100)
+  })
+})

--- a/src/__tests__/audioEngine.test.ts
+++ b/src/__tests__/audioEngine.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { noteToFrequency, AudioEngine } from '../audio/audioEngine'
+
+// Mock AudioContext globally
+function createMockAudioContext() {
+  const mockOscillator = {
+    type: 'sine' as OscillatorType,
+    frequency: { setValueAtTime: vi.fn() },
+    detune: { setValueAtTime: vi.fn() },
+    connect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+
+  const mockGain = {
+    gain: {
+      value: 0.5,
+      setValueAtTime: vi.fn(),
+      linearRampToValueAtTime: vi.fn(),
+      cancelScheduledValues: vi.fn(),
+    },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }
+
+  return {
+    state: 'running',
+    currentTime: 0,
+    createGain: vi.fn(() => mockGain),
+    createOscillator: vi.fn(() => ({ ...mockOscillator })),
+    destination: {},
+    resume: vi.fn(),
+    close: vi.fn(),
+    _mockGain: mockGain,
+    _mockOscillator: mockOscillator,
+  }
+}
+
+describe('noteToFrequency', () => {
+  it('converts A4 to 440 Hz', () => {
+    expect(noteToFrequency('A4')).toBe(440)
+  })
+
+  it('converts C4 to approximately 261.63 Hz', () => {
+    expect(noteToFrequency('C4')).toBeCloseTo(261.63, 1)
+  })
+
+  it('C#4 is higher than C4', () => {
+    expect(noteToFrequency('C#4')).toBeGreaterThan(noteToFrequency('C4'))
+  })
+
+  it('converts Bb3 correctly (enharmonic with A#3)', () => {
+    expect(noteToFrequency('Bb3')).toBeCloseTo(noteToFrequency('A#3'), 5)
+  })
+
+  it('throws on invalid note format', () => {
+    expect(() => noteToFrequency('X4')).toThrow()
+  })
+
+  it('throws on empty string', () => {
+    expect(() => noteToFrequency('')).toThrow()
+  })
+
+  it('handles octave boundaries correctly: B3 < C4', () => {
+    expect(noteToFrequency('B3')).toBeLessThan(noteToFrequency('C4'))
+  })
+})
+
+describe('AudioEngine', () => {
+  let mockCtx: ReturnType<typeof createMockAudioContext>
+
+  beforeEach(() => {
+    mockCtx = createMockAudioContext()
+    // @ts-ignore
+    global.AudioContext = vi.fn(() => mockCtx)
+  })
+
+  it('is not ready before initialization', () => {
+    const engine = new AudioEngine()
+    expect(engine.isReady).toBe(false)
+  })
+
+  it('is ready after initialization with running context', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    expect(engine.isReady).toBe(true)
+  })
+
+  it('resumes suspended context on initialize', async () => {
+    mockCtx.state = 'suspended' as any
+    // @ts-ignore
+    global.AudioContext = vi.fn(() => ({ ...mockCtx, state: 'suspended', resume: vi.fn(async () => { mockCtx.state = 'running' as any }) }))
+    const engine = new AudioEngine()
+    await engine.initialize()
+    // resume was called
+    const ctx = (global.AudioContext as any).mock.results[0].value
+    expect(ctx.resume).toHaveBeenCalled()
+  })
+
+  it('playNote creates oscillator and gain node', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    engine.playNote('A4')
+    expect(mockCtx.createOscillator).toHaveBeenCalled()
+    expect(mockCtx.createGain).toHaveBeenCalled()
+  })
+
+  it('playNote does nothing if context is not ready', () => {
+    const engine = new AudioEngine()
+    // Not initialized
+    engine.playNote('A4')
+    expect(mockCtx.createOscillator).not.toHaveBeenCalled()
+  })
+
+  it('stopNote triggers release envelope on gain', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    engine.playNote('C4')
+    engine.stopNote('C4')
+    expect(mockCtx._mockGain.gain.linearRampToValueAtTime).toHaveBeenCalledWith(0, expect.any(Number))
+  })
+
+  it('stopNote on non-existing note does nothing', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    // Should not throw
+    expect(() => engine.stopNote('Z9')).not.toThrow()
+  })
+
+  it('stopAll clears all active notes', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    engine.playNote('C4')
+    engine.playNote('E4')
+    engine.playNote('G4')
+    engine.stopAll()
+    // After stopAll, calling stopAll again should be a no-op (all notes gone)
+    const callCountBefore = mockCtx._mockGain.gain.linearRampToValueAtTime.mock.calls.length
+    engine.stopAll()
+    const callCountAfter = mockCtx._mockGain.gain.linearRampToValueAtTime.mock.calls.length
+    expect(callCountAfter).toBe(callCountBefore)
+  })
+
+  it('playing same note twice stops the previous one first', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    engine.playNote('A4')
+    const gainCallsBefore = mockCtx._mockGain.gain.linearRampToValueAtTime.mock.calls.length
+    engine.playNote('A4') // should stop old, play new
+    // linearRampToValueAtTime called at least once for the stop envelope
+    expect(mockCtx._mockGain.gain.linearRampToValueAtTime.mock.calls.length).toBeGreaterThan(gainCallsBefore)
+  })
+
+  it('dispose calls context.close()', async () => {
+    const engine = new AudioEngine()
+    await engine.initialize()
+    engine.dispose()
+    expect(mockCtx.close).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/useKeyboard.test.tsx
+++ b/src/__tests__/useKeyboard.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useKeyboard } from '../hooks/useKeyboard'
+
+function fireKeyDown(key: string, repeat = false) {
+  const event = new KeyboardEvent('keydown', { key, repeat, bubbles: true })
+  window.dispatchEvent(event)
+}
+
+function fireKeyUp(key: string) {
+  const event = new KeyboardEvent('keyup', { key, bubbles: true })
+  window.dispatchEvent(event)
+}
+
+describe('useKeyboard', () => {
+  let onNoteOn: ReturnType<typeof vi.fn>
+  let onNoteOff: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    onNoteOn = vi.fn()
+    onNoteOff = vi.fn()
+  })
+
+  it('key "z" triggers noteOn for C3', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => fireKeyDown('z'))
+    expect(onNoteOn).toHaveBeenCalledWith('C3', 100)
+  })
+
+  it('key "s" triggers noteOn for C#3', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => fireKeyDown('s'))
+    expect(onNoteOn).toHaveBeenCalledWith('C#3', 100)
+  })
+
+  it('keyup triggers noteOff', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => {
+      fireKeyDown('z')
+      fireKeyUp('z')
+    })
+    expect(onNoteOff).toHaveBeenCalledWith('C3')
+  })
+
+  it('holding key (repeat=true) does not re-trigger noteOn', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => {
+      fireKeyDown('z')
+      fireKeyDown('z', true) // repeat
+      fireKeyDown('z', true) // repeat again
+    })
+    expect(onNoteOn).toHaveBeenCalledTimes(1)
+  })
+
+  it('unrecognized keys do not trigger callbacks', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => {
+      fireKeyDown('F1')
+      fireKeyUp('F1')
+    })
+    expect(onNoteOn).not.toHaveBeenCalled()
+    expect(onNoteOff).not.toHaveBeenCalled()
+  })
+
+  it('uppercase keys are handled (case-insensitive)', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => fireKeyDown('Z')) // uppercase Z
+    expect(onNoteOn).toHaveBeenCalledWith('C3', 100)
+  })
+
+  it('q key triggers C4', () => {
+    renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    act(() => fireKeyDown('q'))
+    expect(onNoteOn).toHaveBeenCalledWith('C4', 100)
+  })
+
+  it('listeners are removed on unmount', () => {
+    const { unmount } = renderHook(() => useKeyboard(onNoteOn, onNoteOff))
+    unmount()
+    act(() => fireKeyDown('z'))
+    expect(onNoteOn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #6

Adds comprehensive unit tests covering all major modules of the piano application.

## Test Coverage

### `audioEngine.test.ts` (17 tests)
- `noteToFrequency`: A4=440Hz, C4≈261.63Hz, C#4>C4, enharmonics, invalid input, octave boundaries
- `AudioEngine`: initialization, isReady state, playNote creates oscillator+gain, stopNote triggers release envelope, stopAll clears all notes, duplicate note handling, dispose calls close()

### `useKeyboard.test.tsx` (8 tests)
- Key 'z' triggers noteOn for C3
- Key 's' triggers noteOn for C#3
- keyup triggers noteOff
- repeat=true keydown is ignored
- Unrecognized keys don't trigger callbacks
- Case-insensitive key matching
- Listeners removed on unmount

### `PianoKeyboard.test.tsx` (9 tests)
- Renders 14 white keys for 2-octave view
- Renders 10 black keys for 2-octave view
- Prev/Next octave buttons present
- Initial range label displayed
- Next/Prev buttons update range label
- Clicking white/black key calls onNoteOn
- mouseup calls onNoteOff

### `PianoKey.test.tsx` (15 tests)
- White/black key class names
- aria-pressed false/true based on isActive
- aria-label contains note name
- showNoteLabel shows/hides note span
- showShortcutLabel shows/hides shortcut span
- Mouse event callbacks (mouseDown, mouseUp, mouseLeave)
- Active class applied when isActive=true

## Results
```
Test Files  5 passed (5)
     Tests  50 passed (50)
```