### PR TITLE
[Feat] MIDI Keyboard Support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,20 @@
 import React from 'react'
 import PianoKeyboard from './components/PianoKeyboard'
 import { useAudioEngine } from './hooks/useAudioEngine'
+import { useMidi } from './hooks/useMidi'
 
 export default function App(): React.JSX.Element {
   const { playNote, stopNote } = useAudioEngine()
+  const { isSupported, isConnected } = useMidi({ onNoteOn: playNote, onNoteOff: stopNote })
+  
   return (
     <div className="app">
       <h1>Piano</h1>
+      {isSupported && (
+        <div className="midi-status">
+          MIDI: {isConnected ? '🎹 Connected' : 'No device'}
+        </div>
+      )}
       <PianoKeyboard
         baseOctave={3}
         octaves={2}

--- a/src/hooks/useMidi.ts
+++ b/src/hooks/useMidi.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface MidiOptions {
+  onNoteOn: (note: string, velocity: number) => void
+  onNoteOff: (note: string) => void
+}
+
+// MIDI note number to note name (e.g. 60 -> 'C4')
+export function midiNoteToName(midiNote: number): string {
+  const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+  const octave = Math.floor(midiNote / 12) - 1
+  const note = NOTE_NAMES[midiNote % 12]
+  return `${note}${octave}`
+}
+
+export function useMidi({ onNoteOn, onNoteOff }: MidiOptions): { isSupported: boolean; isConnected: boolean } {
+  const isSupported = typeof navigator !== 'undefined' && 'requestMIDIAccess' in navigator
+  const [isConnected, setIsConnected] = useState(false)
+  const onNoteOnRef = useRef(onNoteOn)
+  const onNoteOffRef = useRef(onNoteOff)
+
+  useEffect(() => {
+    onNoteOnRef.current = onNoteOn
+    onNoteOffRef.current = onNoteOff
+  })
+
+  useEffect(() => {
+    if (!isSupported) return
+
+    let midiAccess: MIDIAccess | null = null
+
+    const handleMidiMessage = (event: MIDIMessageEvent) => {
+      const data = event.data
+      if (!data || data.length < 3) return
+
+      const status = data[0]
+      const noteNumber = data[1]
+      const velocity = data[2]
+      const messageType = status & 0xf0
+
+      const noteName = midiNoteToName(noteNumber)
+
+      if (messageType === 0x90 && velocity > 0) {
+        // Note On
+        onNoteOnRef.current(noteName, velocity)
+      } else if (messageType === 0x80 || (messageType === 0x90 && velocity === 0)) {
+        // Note Off
+        onNoteOffRef.current(noteName)
+      }
+    }
+
+    const setupInputs = (access: MIDIAccess) => {
+      access.inputs.forEach((input) => {
+        input.onmidimessage = handleMidiMessage
+      })
+      setIsConnected(access.inputs.size > 0)
+    }
+
+    const handleStateChange = (access: MIDIAccess) => {
+      setupInputs(access)
+    }
+
+    navigator.requestMIDIAccess().then((access) => {
+      midiAccess = access
+      setupInputs(access)
+      access.onstatechange = () => handleStateChange(access)
+    }).catch(() => {
+      // MIDI access denied or unavailable
+    })
+
+    return () => {
+      if (midiAccess) {
+        midiAccess.inputs.forEach((input) => {
+          input.onmidimessage = null
+        })
+        midiAccess.onstatechange = null
+      }
+    }
+  }, [isSupported])
+
+  return { isSupported, isConnected }
+}


### PR DESCRIPTION
Closes #4

## Changes
- Added `src/hooks/useMidi.ts` with Web MIDI API support
- Added `midiNoteToName` utility to convert MIDI note numbers to note names (e.g. 60 -> C4)
- Updated `src/App.tsx` to use the MIDI hook and display connection status
- Handles note-on, note-off, and velocity=0 as note-off