### PR TITLE
chore: exclude e2e from vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: []
-  }
+    setupFiles: [],
+    exclude: ['**/node_modules/**', '**/e2e/**'],
+  },
 })


### PR DESCRIPTION
Exclude `e2e/` directory from vitest to prevent playwright test() from conflicting with vitest globals.