### PR TITLE
fix: correct black key position and enlarge keyboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ export default function App(): React.JSX.Element {
       )}
       <PianoKeyboard
         baseOctave={3}
-        octaves={2}
+        octaves={3}
         showNoteLabels={true}
         showShortcutLabels={true}
         onNoteOn={playNote}

--- a/src/components/Piano.css
+++ b/src/components/Piano.css
@@ -1,7 +1,7 @@
 /* Piano CSS — Superhuman dark theme */
 .piano-keyboard-wrapper {
-  --piano-white-key-width: clamp(20px, 2.3vw, 26px);
-  --piano-white-key-height: clamp(100px, 12vw, 140px);
+  --piano-white-key-width: clamp(36px, 3.5vw, 52px);
+  --piano-white-key-height: clamp(140px, 16vw, 200px);
   --piano-black-key-width: calc(var(--piano-white-key-width) * 0.6);
   --piano-black-key-height: calc(var(--piano-white-key-height) * 0.65);
   --piano-color-accent: #cbb7fb;
@@ -11,6 +11,9 @@
   align-items: center;
   gap: 0.75rem;
   user-select: none;
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: auto;
 }
 
 .piano-octave-controls {
@@ -151,7 +154,7 @@
 
 @media (max-width: 600px) {
   .piano-keyboard-wrapper {
-    --piano-white-key-width: clamp(16px, 4vw, 22px);
-    --piano-white-key-height: clamp(80px, 18vw, 110px);
+    --piano-white-key-width: clamp(18px, 4.5vw, 28px);
+    --piano-white-key-height: clamp(90px, 20vw, 130px);
   }
 }

--- a/src/components/PianoKeyboard.tsx
+++ b/src/components/PianoKeyboard.tsx
@@ -88,7 +88,7 @@ export default function PianoKeyboard({
           />
         ))}
         {/* Black keys overlay */}
-        <div style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none', display: 'contents' }}>
+        <div style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none', width: '100%', height: '100%' }}>
           {blackKeyPositions.map(({ key: k, whiteIndex }) => (
             <div
               key={k.note}


### PR DESCRIPTION
Closes #18
Closes #20

## Changes
- Fix black key overlay: remove `display:contents`, use proper absolute positioning with `width/height: 100%`
- Enlarge white keys: `clamp(20px,2.3vw,26px)` → `clamp(36px,3.5vw,52px)`
- Default octaves: 2 → 3 (shows C3–B5 on PC)
- Add `overflow-x: auto` for scrollability on small screens

## Test
All 50 unit tests pass.