### PR TITLE
fix: wire AudioControls to shared engine, fix volume control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,25 @@ import { useMidi } from './hooks/useMidi'
 import AudioControls from './components/AudioControls'
 
 export default function App(): React.JSX.Element {
-  const { playNote, stopNote } = useAudioEngine()
+  const {
+    playNote,
+    stopNote,
+    volume,
+    timbre,
+    setVolume,
+    setTimbre,
+  } = useAudioEngine()
   const { isSupported, isConnected } = useMidi({ onNoteOn: playNote, onNoteOff: stopNote })
   
   return (
     <div className="app">
       <h1>Piano</h1>
-      <AudioControls />
+      <AudioControls
+        volume={volume}
+        onVolumeChange={setVolume}
+        timbre={timbre}
+        onTimbreChange={setTimbre}
+      />
       {isSupported && (
         <div className="midi-status">
           MIDI: {isConnected ? '🎹 Connected' : 'No device'}

--- a/src/components/AudioControls.tsx
+++ b/src/components/AudioControls.tsx
@@ -1,50 +1,55 @@
 import React, { useMemo } from 'react'
-import { useAudioEngine } from '../hooks/useAudioEngine'
 import './AudioControls.css'
 
-// Timbre options align with Web Audio OscillatorType: 'sine' | 'triangle' | 'square' | 'sawtooth'
+// Props-driven AudioControls: controlled by App via shared AudioEngine state
 type Timbre = 'sine' | 'triangle' | 'square' | 'sawtooth' | string
+type AudioControlsProps = {
+  volume: number
+  onVolumeChange: (v: number) => void
+  timbre: OscillatorType
+  onTimbreChange: (t: OscillatorType) => void
+}
 
-export default function AudioControls(): React.JSX.Element {
-  const { setVolume, setTimbre } = useAudioEngine()
-  // Local UI state mirrors engine state for a responsive UI vibe
+// Timbre options align with Web Audio OscillatorType: 'sine' | 'triangle' | 'square' | 'sawtooth'
+
+export default function AudioControls({ volume, onVolumeChange, timbre, onTimbreChange }: AudioControlsProps): React.JSX.Element {
+  // Timbre options align with Web Audio OscillatorType: 'sine' | 'triangle' | 'square' | 'sawtooth'
   const timbres: Timbre[] = useMemo(() => ['sine', 'triangle', 'square', 'sawtooth'], [])
-
   // Handlers
-  const onVolumeChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+  const handleVolumeChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     const v = parseFloat(e.target.value)
-    setVolume(v)
+    onVolumeChange(v)
   }
 
-  const onTimbreChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+  const handleTimbreChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
     const t = e.target.value as OscillatorType
-    setTimbre(t)
+    onTimbreChange(t)
   }
 
-  // Simple controlled defaults (these will be overridden by engine, but provide sensible initial values)
-  return (
-    <div className="audio-controls">
-      <div className="audio-controls__group">
-        <label className="audio-controls__label" htmlFor="volume">Volume</label>
-        <input
-          id="volume"
-          className="audio-controls__slider"
-          type="range"
-          min={0}
-          max={1}
-          step={0.01}
-          defaultValue={1}
-          onChange={onVolumeChange}
-        />
-      </div>
-      <div className="audio-controls__group">
-        <label className="audio-controls__label" htmlFor="timbre">Timbre</label>
-        <select id="timbre" className="audio-controls__select" onChange={onTimbreChange} defaultValue={'triangle'}>
-          {timbres.map((t) => (
-            <option key={t} value={t}>{t}</option>
-          ))}
-        </select>
-      </div>
-    </div>
-  )
+	// Simple controlled inputs bound to props
+	return (
+		<div className="audio-controls">
+		  <div className="audio-controls__group">
+			<label className="audio-controls__label" htmlFor="volume">Volume</label>
+            <input
+              id="volume"
+              className="audio-controls__slider"
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={volume}
+              onChange={handleVolumeChange}
+            />
+		  </div>
+		  <div className="audio-controls__group">
+			<label className="audio-controls__label" htmlFor="timbre">Timbre</label>
+            <select id="timbre" className="audio-controls__select" value={timbre} onChange={handleTimbreChange}>
+			  {timbres.map((t) => (
+				<option key={t} value={t}>{t}</option>
+			  ))}
+			</select>
+		  </div>
+		</div>
+	)
 }

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -6,6 +6,8 @@ export interface AudioEngineHook {
   playNote: (note: string, velocity?: number) => void
   stopNote: (note: string) => void
   isReady: boolean
+  volume: number
+  timbre: OscillatorType
   setVolume: (volume: number) => void
   setTimbre: (timbre: OscillatorType) => void
 }
@@ -13,6 +15,9 @@ export interface AudioEngineHook {
 export function useAudioEngine(): AudioEngineHook {
   const engineRef = useRef<AudioEngine | null>(null)
   const [isReady, setIsReady] = useState(false)
+  // UI state mirrors engine state for synchronization
+  const [volume, setVolumeState] = useState<number>(0.7)
+  const [timbre, setTimbreState] = useState<OscillatorType>('triangle')
 
   // Lazily create engine
   if (!engineRef.current) {
@@ -51,13 +56,23 @@ export function useAudioEngine(): AudioEngineHook {
 
   const setVolume = useCallback((volume: number) => {
     engineRef.current?.setVolume(volume)
+    setVolumeState(volume)
   }, [])
 
   const setTimbre = useCallback((timbre: OscillatorType) => {
     engineRef.current?.setTimbre(timbre)
+    setTimbreState(timbre)
   }, [])
 
-  return { playNote, stopNote, isReady, setVolume, setTimbre }
+  return {
+    playNote,
+    stopNote,
+    isReady,
+    volume,
+    timbre,
+    setVolume,
+    setTimbre,
+  }
 }
 
 export default useAudioEngine


### PR DESCRIPTION
Closes #23

## Root Cause
AudioControls called useAudioEngine() internally, creating a **second** AudioEngine instance. Volume changes were applied to a ghost engine that never played any notes.

## Fix
- AudioControls now accepts volume/timbre as props (controlled component)
- useAudioEngine exposes volume + timbre state
- App.tsx wires a single shared engine to AudioControls

## Tests
Build ✅ | 50/50 tests ✅