### PR TITLE
feat: real piano samples via Tone.js Sampler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "tone": "^14.9.17"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -269,7 +270,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1611,6 +1611,19 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/automation-events": {
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.19.tgz",
+      "integrity": "sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -3803,6 +3816,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -3917,6 +3941,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tone": {
+      "version": "14.9.17",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-14.9.17.tgz",
+      "integrity": "sha512-+Qb7M4NMua+tb5Z52+MEVmjye0fjJuIFBePx423pqr9E6/lHDqZAG+fUAvo+Ujm48q0s9bVLRAyT1ETJJglNtg==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -3945,6 +3979,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "tone": "^14.9.17"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ export default function App(): React.JSX.Element {
         onVolumeChange={setVolume}
         timbre={timbre}
         onTimbreChange={setTimbre}
+        showTimbre={false}
       />
       {isSupported && (
         <div className="midi-status">

--- a/src/__mocks__/tone.ts
+++ b/src/__mocks__/tone.ts
@@ -1,0 +1,34 @@
+// Minimal Tone.js mock for Vitest environment
+// Exposes Sampler and Destination to satisfy tests that import from 'tone'
+
+export class Sampler {
+  constructor() {
+    // expose volume API surface that tests may interact with
+    this.volume = { value: 0 }
+  }
+
+  toDestination() {
+    // mimic Tone.js connection API
+    return this
+  }
+
+  triggerAttack() {
+    // no-op mock
+  }
+
+  triggerRelease() {
+    // no-op mock
+  }
+
+  disconnect() {
+    // no-op mock
+  }
+}
+
+export const Destination = {}
+
+// Optional default export for compatibility with code that imports Tone.js as a default namespace
+export default {
+  Sampler,
+  Destination
+}

--- a/src/audio/samplerEngine.ts
+++ b/src/audio/samplerEngine.ts
@@ -1,0 +1,115 @@
+import * as Tone from 'tone'
+
+// Sampler-based audio engine using Tone.js with real piano samples
+// Samples loaded from: https://gleitz.github.io/midi-js-soundfonts/MusyngKite/acoustic_grand_piano-mp3/
+
+type NoteName = string
+
+export class SamplerEngine {
+  private sampler: Tone.Sampler | null = null
+  private _ready: boolean = false
+  private _readyPromise: Promise<void> | null = null
+  private _resolveReady?: () => void
+
+  constructor() {
+    // Nothing to do here; lazy initialize in initialize()
+  }
+
+  get isReady(): boolean {
+    return this._ready
+  }
+
+  // Initialize Tone context and preload samples
+  async initialize(): Promise<void> {
+    if (!this.sampler) {
+      // Build sample map for all required notes
+      const notes: string[] = [
+        'A0','C1','D#1','F#1','A1','C2','D#2','F#2','A2','C3','D#3','F#3','A3','C4','D#4','F#4','A4','C5','D#5','F#5','A5','C6','D#6','F#6','A6','C7','D#7','F#7','A7','C8'
+      ]
+      const baseUrl = 'https://gleitz.github.io/midi-js-soundfonts/MusyngKite/acoustic_grand_piano-mp3/'
+      const samples: Record<string, string> = {}
+      for (const n of notes) {
+        // Note: the URL pattern uses the note filename directly
+        samples[n] = `${n}.mp3`
+      }
+
+      // Create the sampler with onload callback
+      this.sampler = new Tone.Sampler(samples, () => {
+        this._ready = true
+        this._resolveReady?.()
+      }, baseUrl)
+      // Route to destination
+      this.sampler.toDestination()
+    }
+
+    // Ensure AudioContext is running
+    if (Tone.context.state === 'suspended') {
+      await Tone.context.resume()
+    }
+
+    if (!this._readyPromise) {
+      this._readyPromise = new Promise<void>((resolve) => {
+        this._resolveReady = resolve
+      })
+    }
+    await this._readyPromise
+  }
+
+  // Play a note using the sampler
+  playNote(note: NoteName, velocity: number = 1): void {
+    if (!this.sampler) return
+    // Trigger the sample; Tone.Sampler supports velocity via velocity parameter in triggerAttack
+    // If not available, fall back to triggerAttack with default duration
+    try {
+      // Some Tone versions require time arg; use now() for immediate playback
+      // @ts-ignore - type may differ across Tone versions
+      this.sampler.triggerAttack(note, Tone.now(), velocity)
+    } catch {
+      try {
+        // Fallback API
+        // @ts-ignore
+        this.sampler.triggerAttack(note, 0, velocity)
+      } catch {
+        // Last resort: triggerAttack with just note
+        // @ts-ignore
+        this.sampler.triggerAttack(note)
+      }
+    }
+  }
+
+  stopNote(note: NoteName): void {
+    if (!this.sampler) return
+    // Stop the sample
+    try {
+      // @ts-ignore - method exists on Tone.Sampler
+      this.sampler.triggerRelease(note)
+    } catch {
+      // Some versions may not support explicit release; ignore
+    }
+  }
+
+  setVolume(volume: number): void {
+    // Map 0..1 to -40dB .. 0dB
+    const v = Math.max(0, Math.min(1, volume))
+    const db = -40 + v * 40
+    if (this.sampler) {
+      // Tone.Sampler exposes a 'volume' property (a GainNode) with .value in dB
+      // @ts-ignore
+      this.sampler.volume.value = db
+    }
+  }
+
+  setTimbre(_timbre: OscillatorType): void {
+    // No-op for sampler
+  }
+
+  dispose(): void {
+    this.sampler?.dispose()
+    this.sampler = null
+    this._ready = false
+    this._readyPromise = null
+    this._resolveReady = undefined
+  }
+}
+
+export default SamplerEngine

--- a/src/components/AudioControls.tsx
+++ b/src/components/AudioControls.tsx
@@ -8,11 +8,12 @@ type AudioControlsProps = {
   onVolumeChange: (v: number) => void
   timbre: OscillatorType
   onTimbreChange: (t: OscillatorType) => void
+  showTimbre?: boolean
 }
 
 // Timbre options align with Web Audio OscillatorType: 'sine' | 'triangle' | 'square' | 'sawtooth'
 
-export default function AudioControls({ volume, onVolumeChange, timbre, onTimbreChange }: AudioControlsProps): React.JSX.Element {
+export default function AudioControls({ volume, onVolumeChange, timbre, onTimbreChange, showTimbre = false }: AudioControlsProps): React.JSX.Element {
   // Timbre options align with Web Audio OscillatorType: 'sine' | 'triangle' | 'square' | 'sawtooth'
   const timbres: Timbre[] = useMemo(() => ['sine', 'triangle', 'square', 'sawtooth'], [])
   // Handlers
@@ -42,14 +43,16 @@ export default function AudioControls({ volume, onVolumeChange, timbre, onTimbre
               onChange={handleVolumeChange}
             />
 		  </div>
-		  <div className="audio-controls__group">
-			<label className="audio-controls__label" htmlFor="timbre">Timbre</label>
-            <select id="timbre" className="audio-controls__select" value={timbre} onChange={handleTimbreChange}>
-			  {timbres.map((t) => (
-				<option key={t} value={t}>{t}</option>
-			  ))}
-			</select>
-		  </div>
+		  {showTimbre && (
+		    <div className="audio-controls__group">
+		      <label className="audio-controls__label" htmlFor="timbre">Timbre</label>
+		      <select id="timbre" className="audio-controls__select" value={timbre} onChange={handleTimbreChange}>
+		        {timbres.map((t) => (
+		          <option key={t} value={t}>{t}</option>
+		        ))}
+		      </select>
+		    </div>
+		  )}
 		</div>
 	)
 }

--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AudioEngine } from '../audio/audioEngine'
-import { pianoInstrument } from '../audio/instruments'
+import { SamplerEngine } from '../audio/samplerEngine'
 
 export interface AudioEngineHook {
   playNote: (note: string, velocity?: number) => void
@@ -13,7 +12,7 @@ export interface AudioEngineHook {
 }
 
 export function useAudioEngine(): AudioEngineHook {
-  const engineRef = useRef<AudioEngine | null>(null)
+  const engineRef = useRef<SamplerEngine | null>(null)
   const [isReady, setIsReady] = useState(false)
   // UI state mirrors engine state for synchronization
   const [volume, setVolumeState] = useState<number>(0.7)
@@ -21,7 +20,7 @@ export function useAudioEngine(): AudioEngineHook {
 
   // Lazily create engine
   if (!engineRef.current) {
-    engineRef.current = new AudioEngine(pianoInstrument)
+    engineRef.current = new SamplerEngine()
   }
 
   // Clean up on unmount
@@ -60,6 +59,7 @@ export function useAudioEngine(): AudioEngineHook {
   }, [])
 
   const setTimbre = useCallback((timbre: OscillatorType) => {
+    // No-op for sampler engine; keep API compatibility
     engineRef.current?.setTimbre(timbre)
     setTimbreState(timbre)
   }, [])

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
@@ -8,5 +9,11 @@ export default defineConfig({
     globals: true,
     setupFiles: [],
     exclude: ['**/node_modules/**', '**/e2e/**'],
+  },
+  resolve: {
+    alias: {
+      // Mock Tone.js module to avoid ESM resolution issues in Vitest
+      'tone': path.resolve(process.cwd(), 'src/__mocks__/tone.ts')
+    }
   },
 })


### PR DESCRIPTION
Closes #24

## Changes
- Install Tone.js
- New `src/audio/samplerEngine.ts`: loads MusyngKite acoustic_grand_piano MP3 samples from CDN
- `useAudioEngine`: switch to SamplerEngine (setTimbre becomes no-op)
- `AudioControls`: hide timbre selector for sampler mode
- Vitest mock for Tone.js to keep tests working

## Tests
Build ✅ | 50/50 tests ✅