### PR TITLE
fix: call Tone.start() before Sampler init to unlock AudioContext

### DIFF
--- a/src/__mocks__/tone.ts
+++ b/src/__mocks__/tone.ts
@@ -27,8 +27,12 @@ export class Sampler {
 
 export const Destination = {}
 
+// Provide a mock for Tone.start used to unlock AudioContext in tests
+export const start = vi.fn().mockResolvedValue(undefined)
+
 // Optional default export for compatibility with code that imports Tone.js as a default namespace
 export default {
   Sampler,
-  Destination
+  Destination,
+  start
 }

--- a/src/audio/samplerEngine.ts
+++ b/src/audio/samplerEngine.ts
@@ -21,6 +21,8 @@ export class SamplerEngine {
 
   // Initialize Tone context and preload samples
   async initialize(): Promise<void> {
+    // Unlock AudioContext as early as possible to satisfy autoplay policies
+    await Tone.start()
     if (!this.sampler) {
       // Build sample map for all required notes
       const notes: string[] = [


### PR DESCRIPTION
Closes #27

## Root Cause
`initialize()` built the Tone.Sampler without first calling `Tone.start()`. Browser autoplay policy blocks AudioContext creation outside of a user gesture.

## Fix
Added `await Tone.start()` as the first line of `samplerEngine.initialize()`, ensuring AudioContext is unlocked on first keypress before the Sampler loads.

## Tests
- Updated `src/__mocks__/tone.ts` to export `start` mock
- All 50 tests pass