### PR TITLE
fix: correct black key position calculation

### DIFF
--- a/src/components/PianoKeyboard.tsx
+++ b/src/components/PianoKeyboard.tsx
@@ -62,8 +62,9 @@ export default function PianoKeyboard({
     if (!k.isBlack) {
       whiteIdx++
     } else {
-      // black key sits between previous white key and next
-      blackKeyPositions.push({ key: k, whiteIndex: whiteIdx - 0.5 })
+      // black key sits on the right edge of the previous white key
+      // translateX(-50%) in CSS will center it between the two white keys
+      blackKeyPositions.push({ key: k, whiteIndex: whiteIdx })
     }
   }
 


### PR DESCRIPTION
## 問題
黑鍵位置偏移，沒有正確交錯在白鍵之間。

## 根本原因
`whiteIndex: whiteIdx - 0.5` 導致黑鍵中心落在前一個白鍵的中間。

## 修法
改為 `whiteIndex: whiteIdx`，配合 CSS `translateX(-50%)`，黑鍵自動居中於兩個白鍵邊界。

Closes #31