### PR TITLE
feat: add touch support for mobile devices

### DIFF
--- a/src/components/PianoKey.tsx
+++ b/src/components/PianoKey.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import * as Tone from 'tone'
 import type { PianoKeyProps } from '../types/piano'
 import './Piano.css'
 
@@ -30,8 +31,18 @@ export default function PianoKey({
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseLeave}
-      onTouchStart={(e) => { e.preventDefault(); onNoteOn(note, 100) }}
+      onTouchStart={async (e) => {
+        // Prevent 300ms mobile click delay and ensure AudioContext is started in touch gesture
+        e.preventDefault()
+        try {
+          await Tone.start()
+        } catch {
+          // ignore startup errors; Tone may already be started or unavailable in test env
+        }
+        onNoteOn(note, 100)
+      }}
       onTouchEnd={() => onNoteOff(note)}
+      onTouchCancel={() => onNoteOff(note)}
     >
       <span className="piano-key__labels">
         {showShortcutLabel && shortcut && (


### PR DESCRIPTION
新增 onTouchStart/onTouchEnd 事件，在 touch gesture 中呼叫 Tone.start() 解除 AudioContext 限制，支援多指觸控。

Closes MIK-6