### PR TITLE
fix: reduce default volume to prevent clipping

### DIFF
--- a/src/hooks/useAudioEngine.ts
+++ b/src/hooks/useAudioEngine.ts
@@ -15,7 +15,7 @@ export function useAudioEngine(): AudioEngineHook {
   const engineRef = useRef<SamplerEngine | null>(null)
   const [isReady, setIsReady] = useState(false)
   // UI state mirrors engine state for synchronization
-  const [volume, setVolumeState] = useState<number>(0.7)
+  const [volume, setVolumeState] = useState<number>(0.4)
   const [timbre, setTimbreState] = useState<OscillatorType>('triangle')
 
   // Lazily create engine


### PR DESCRIPTION
Closes #15

## Summary
Reduce default volume from 0.7 to 0.4 to prevent audio clipping on piano key presses.

The previous value of 0.7 combined with gainMultiplier=0.5 and high velocity could produce gain values that cause clipping. Setting default to 0.4 provides a comfortable starting level with headroom.

## Tests
- All 50 existing tests pass
- Build passes